### PR TITLE
Update gcalculator.rb

### DIFF
--- a/packages/gcalculator.rb
+++ b/packages/gcalculator.rb
@@ -3,22 +3,16 @@ require 'package'
 class Gcalculator < Package
   description 'Calculator for solving mathematical equations'
   homepage 'https://gitlab.gnome.org/GNOME/gnome-calculator'
-  version '3.36.0'
+  version '3.38.1'
   compatibility 'all'
-  source_url 'https://gitlab.gnome.org/GNOME/gnome-calculator/-/archive/3.36.0/gnome-calculator-3.36.0.tar.bz2'
-  source_sha256 '9d82e8b32cd3c41517d9bfc234b88359b1bef8f1bfa02994b622788272846b3a'
+  source_url 'https://gitlab.gnome.org/GNOME/gnome-calculator/-/archive/3.38.1/gnome-calculator-3.38.1.tar.bz2'
+  source_sha256 '07dc348eef03f81fbe9c99f30836e0a1438942e5a9e79655772414eb5b09b691'
 
   binary_url ({
-    aarch64: 'https://dl.bintray.com/chromebrew/chromebrew/gcalculator-3.36.0-chromeos-armv7l.tar.xz',
-     armv7l: 'https://dl.bintray.com/chromebrew/chromebrew/gcalculator-3.36.0-chromeos-armv7l.tar.xz',
-       i686: 'https://dl.bintray.com/chromebrew/chromebrew/gcalculator-3.36.0-chromeos-i686.tar.xz',
-     x86_64: 'https://dl.bintray.com/chromebrew/chromebrew/gcalculator-3.36.0-chromeos-x86_64.tar.xz',
+    
   })
   binary_sha256 ({
-    aarch64: '6ef512061c2826d965bbc6be61d1070b96f815daedfb047f4ea958059825e1bc',
-     armv7l: '6ef512061c2826d965bbc6be61d1070b96f815daedfb047f4ea958059825e1bc',
-       i686: '7152af3ed58253c04bb23edfed46213107d1584f9fb6bb92a349139840ce099b',
-     x86_64: 'b75a8c4fd588b2546389a1817a808420b68a73db71af95b2c3bb5d49e473ccbf',
+    
   })
 
   depends_on 'setuptools' => :build


### PR DESCRIPTION
Updated gnome calculator package source and hash, needs binary
https://gitlab.gnome.org/GNOME/gnome-calculator/-/tags
